### PR TITLE
Relabel volumes when mounting them

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
         ports:
             - 4000
         volumes:
-            - bdcs-recipes-volume:/bdcs-recipes/
-            - bdcs-mddb-volume:/mddb/
+            - bdcs-recipes-volume:/bdcs-recipes/:z
+            - bdcs-mddb-volume:/mddb/:z
 
     web:
         build: ./composer-UI/


### PR DESCRIPTION
This should relabel the volumes when they are mounted.

I've observed a permission error when entrypoint copies over the example
recipe, but it went away on a restart and cannot be reproduced so this
is mostly a preventative measure. Hopefully.