### PR TITLE
Don't specify driver local for volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ import-metadata:
 		echo "ERROR: missing ./metadata.db file" \
 		exit 1; \
 	fi; \
-	sudo docker volume create -d local --name bdcs-mddb-volume
+	sudo docker volume create --name bdcs-mddb-volume
 	sudo docker create --name import-mddb -v bdcs-mddb-volume:/mddb/:z weld/bdcs-api
 	sudo docker cp ./metadata.db import-mddb:/mddb/
 	sudo docker rm import-mddb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,5 @@ services:
 
 volumes:
     bdcs-recipes-volume:
-        driver: local
     bdcs-mddb-volume:
         external: true
-


### PR DESCRIPTION
otherwise I get en error when `make import-metadata`:
Error response from daemon: missing device in volume options

This was on a Fedora 25 host. In Travis even without this patch I'm able to import metadata. SeeRaw log at:
https://travis-ci.org/weldr/welder-web/jobs/225990140
