### PR TITLE
Update to Fedora 28.

### DIFF
--- a/Dockerfile-weld
+++ b/Dockerfile-weld
@@ -1,6 +1,6 @@
-# A Fedora 27 Container
+# A Fedora 28 Container
 # With the libraries and tools needed to build things.
-FROM fedora:27
+FROM fedora:28
 MAINTAINER Brian C. Lane <bcl@redhat.com>
 RUN dnf --setopt=deltarpm=0 --verbose install -y dnf-plugins-core gnupg tar git sudo curl \
 file gcc-c++ gcc gdb glibc-devel openssl-devel make xz sqlite-devel cmake libcurl-devel \

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ default: all
 repos: $(REPOS)
 
 weld-fedora: Dockerfile-weld
-	sudo docker build -t welder/fedora:27 --cache-from welder/fedora:latest -f Dockerfile-weld .
-	sudo docker tag      welder/fedora:27 welder/fedora:latest
+	sudo docker build -t welder/fedora:28 --cache-from welder/fedora:latest -f Dockerfile-weld .
+	sudo docker tag      welder/fedora:28 welder/fedora:latest
 
 # given a repo in REPOS, clone it from GIT_ORG_URL
 $(REPOS):%:


### PR DESCRIPTION
This is needed for cabal >= 2.0, which is needed to allow proper
installation of the bdcs subcommands.